### PR TITLE
Fix crash on initialization of blocks existing before updating to 2.0.2

### DIFF
--- a/src/main/java/me/srrapero720/waterframes/common/block/entity/DisplayTile.java
+++ b/src/main/java/me/srrapero720/waterframes/common/block/entity/DisplayTile.java
@@ -250,7 +250,7 @@ public abstract class DisplayTile extends BlockEntity {
             }
 
             int redstoneOutput = 0;
-            if (tile.data.tick != -1 && tile.data.tickMax != -1 && tile.data.active) {
+            if (tile.data.tick != -1 && tile.data.tickMax != -1 && tile.data.tick <= tile.data.tickMax && tile.data.active) {
                 redstoneOutput = Math.round(((float) tile.data.tick / (float) tile.data.tickMax) * (BlockStateProperties.MAX_LEVEL_15 - 1)) + 1;
             }
 

--- a/src/main/java/me/srrapero720/waterframes/common/block/entity/DisplayTile.java
+++ b/src/main/java/me/srrapero720/waterframes/common/block/entity/DisplayTile.java
@@ -250,7 +250,7 @@ public abstract class DisplayTile extends BlockEntity {
             }
 
             int redstoneOutput = 0;
-            if (tile.data.tickMax != -1 && tile.data.active) {
+            if (tile.data.tick != -1 && tile.data.tickMax != -1 && tile.data.active) {
                 redstoneOutput = Math.round(((float) tile.data.tick / (float) tile.data.tickMax) * (BlockStateProperties.MAX_LEVEL_15 - 1)) + 1;
             }
 


### PR DESCRIPTION
Fixes a crash that I had when loading an existing world after updating to 2.0.2.

The bug is caused by the computation in the `tick` method of `DisplayTitle` when the `tile.data.tick` is `-1` or greater than `tile.data.tickMax`, causing the end result beeing around int.MIN_VALUE, which is illegal for redstone power.

![image](https://github.com/SrRapero720/waterframes/assets/155321034/3a4730b0-ada2-42b8-a8fa-a42110a31d74)

The fix simply skip the calculation when `tile.data.tick` is `-1` and when `tile.data.tick` is greater than `tile.data.tickMax`, leaving output power to 0.