### PR TITLE
Fix the whitelisted URL for Twitch

### DIFF
--- a/src/main/java/me/srrapero720/waterframes/WFConfig.java
+++ b/src/main/java/me/srrapero720/waterframes/WFConfig.java
@@ -49,7 +49,7 @@ public class WFConfig {
             "ytimg.com",
             "youtube.com",
             "youtu.be",
-            "twitch.com",
+            "twitch.tv",
             "twitter.com",
             "soundcloud.com",
             "kick.com",


### PR DESCRIPTION
The previously whitelisted URL was twitch.com, which does redirect to twitch.tv in the browser, but fails to load in the mod and is not what most people would be pasting in.

(Not sure what the linked issue thing is about, not something I did on purpose)