### PR TITLE
Fix 1.21.4 Recipe Errors

### DIFF
--- a/src/main/resources/data/waterframes/recipe/big_tv.json
+++ b/src/main/resources/data/waterframes/recipe/big_tv.json
@@ -1,23 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "misc",
   "pattern": [
     "iIi",
     "iGi",
     "iRi"
   ],
   "key": {
-    "i": {
-      "item": "minecraft:iron_ingot"
-    },
-    "I": {
-      "item": "minecraft:iron_block"
-    },
-    "G": {
-      "item": "minecraft:tinted_glass"
-    },
-    "R": {
-      "item": "waterframes:remote"
-    }
+    "i": "minecraft:iron_ingot",
+    "I": "minecraft:iron_block",
+    "G": "minecraft:tinted_glass",
+    "R": "waterframes:remote"
   },
   "result": {
     "id": "waterframes:big_tv",

--- a/src/main/resources/data/waterframes/recipe/frame.json
+++ b/src/main/resources/data/waterframes/recipe/frame.json
@@ -1,23 +1,16 @@
 {
     "type": "minecraft:crafting_shaped",
+    "category": "misc",
     "pattern": [
         "iGi",
         "iTi",
         "iSi"
     ],
     "key": {
-        "i": {
-            "item": "minecraft:iron_ingot"
-        },
-        "G": {
-            "item": "minecraft:glowstone"
-        },
-        "T": {
-            "item": "minecraft:tinted_glass"
-        },
-        "S": {
-            "item": "waterframes:remote"
-        }
+        "i": "minecraft:iron_ingot",
+        "G": "minecraft:glowstone",
+        "T": "minecraft:tinted_glass",
+        "S": "waterframes:remote"
     },
     "result": {
         "id": "waterframes:frame",

--- a/src/main/resources/data/waterframes/recipe/projector.json
+++ b/src/main/resources/data/waterframes/recipe/projector.json
@@ -1,23 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "misc",
   "pattern": [
     "##A",
     "#GA",
     "#RA"
   ],
   "key": {
-    "#": {
-      "item": "minecraft:iron_block"
-    },
-    "A": {
-      "item": "minecraft:amethyst_shard"
-    },
-    "G": {
-      "item": "minecraft:glowstone"
-    },
-    "R": {
-      "item": "waterframes:remote"
-    }
+    "#": "minecraft:iron_block",
+    "A": "minecraft:amethyst_shard",
+    "G": "minecraft:glowstone",
+    "R": "waterframes:remote"
   },
   "result": {
     "id": "waterframes:projector",

--- a/src/main/resources/data/waterframes/recipe/remote.json
+++ b/src/main/resources/data/waterframes/recipe/remote.json
@@ -1,23 +1,16 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "misc",
   "pattern": [
     "ici",
     "iRi",
     "SSS"
   ],
   "key": {
-    "i": {
-      "item": "minecraft:iron_ingot"
-    },
-    "c": {
-      "item": "minecraft:copper_block"
-    },
-    "R": {
-      "item": "minecraft:redstone"
-    },
-    "S": {
-      "item": "minecraft:stone_button"
-    }
+    "i": "minecraft:iron_ingot",
+    "c": "minecraft:copper_block",
+    "R": "minecraft:redstone",
+    "S": "minecraft:stone_button"
   },
   "result": {
     "id": "waterframes:remote",

--- a/src/main/resources/data/waterframes/recipe/tv.json
+++ b/src/main/resources/data/waterframes/recipe/tv.json
@@ -1,20 +1,15 @@
 {
   "type": "minecraft:crafting_shaped",
+  "category": "misc",
   "pattern": [
     "iii",
     "iGi",
     "iRi"
   ],
   "key": {
-    "i": {
-      "item": "minecraft:iron_ingot"
-    },
-    "G": {
-      "item": "minecraft:tinted_glass"
-    },
-    "R": {
-      "item": "waterframes:remote"
-    }
+    "i": "minecraft:iron_ingot",
+    "G": "minecraft:tinted_glass",
+    "R": "waterframes:remote"
   },
   "result": {
     "id": "waterframes:tv",

--- a/src/main/resources/data/waterframes/recipe/tv_box.json
+++ b/src/main/resources/data/waterframes/recipe/tv_box.json
@@ -1,12 +1,9 @@
 {
   "type": "minecraft:crafting_shapeless",
+  "category": "misc",
   "ingredients": [
-    {
-      "item": "minecraft:note_block"
-    },
-    {
-      "item": "waterframes:frame"
-    }
+   "minecraft:note_block",
+   "waterframes:frame"
   ],
   "result": {
     "id": "waterframes:tv_box",


### PR DESCRIPTION
Tweaks recipes to use strings for "ingredients" and "keys", to prevent formatting errors on Neoforge 1.21.4. 
Also places the recipes in the "Misc" tab of the Recipe Book.


Tested on Windows 10 22H2, Neoforge 21.4.78-beta, Minecraft 1.21.4