### PR TITLE
Fix Texture Registration

### DIFF
--- a/src/main/java/me/srrapero720/waterframes/DisplaysRegistry.java
+++ b/src/main/java/me/srrapero720/waterframes/DisplaysRegistry.java
@@ -224,7 +224,7 @@ public class DisplaysRegistry {
         @SubscribeEvent
         @OnlyIn(Dist.CLIENT)
         public static void registerOtherStuff(FMLClientSetupEvent e) {
-            registerTexture(LOADING_ANIMATION, new TextureWrapper.Renderer(ImageAPI.loadingGif(WaterFrames.ID)));
+            e.enqueueWork(() -> registerTexture(LOADING_ANIMATION, new TextureWrapper.Renderer(ImageAPI.loadingGif(WaterFrames.ID))));
         }
 
         @SubscribeEvent


### PR DESCRIPTION
This PR fixes textures being registered on the wrong thread. Even though it doesn't crash, this can cause a race condition if any other mod attempts to register a texture during client initialization.

Fixes https://github.com/FoundryMC/Veil/issues/57.