### PR TITLE
DisplayData: Don't round the projection distance to an integer

### DIFF
--- a/src/main/java/me/srrapero720/waterframes/common/block/data/DisplayData.java
+++ b/src/main/java/me/srrapero720/waterframes/common/block/data/DisplayData.java
@@ -160,7 +160,7 @@ public class DisplayData {
         }
 
         if (tile.caps.projects()) {
-            this.projectionDistance = nbt.contains(PROJECTION_DISTANCE) ? DisplaysConfig.maxProjDis(nbt.getInt(PROJECTION_DISTANCE)) : this.projectionDistance;
+            this.projectionDistance = nbt.contains(PROJECTION_DISTANCE) ? DisplaysConfig.maxProjDis(nbt.getFloat(PROJECTION_DISTANCE)) : this.projectionDistance;
             this.audioOffset = nbt.contains(AUDIO_OFFSET) ? nbt.getFloat(AUDIO_OFFSET) : this.audioOffset;
         }
 


### PR DESCRIPTION
Projection distance is a float in the UI, yet it is being rounded to an integer when loading the display data.