### PR TITLE
Fix crash on watervision not being installed

### DIFF
--- a/src/main/java/me/srrapero720/watervision/client/screens/VisionScreen.java
+++ b/src/main/java/me/srrapero720/watervision/client/screens/VisionScreen.java
@@ -1,0 +1,13 @@
+package me.srrapero720.watervision.client.screens;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import java.net.URI;
+
+public class VisionScreen extends Screen {
+    public VisionScreen(final URI uri, final int volume, final float speed, final boolean stretch, final float gameFadeDuration, final float videoFadeDuration, final boolean controls, final boolean exit)  {
+        super(Component.literal("WaterVision"));
+        throw new UnsupportedOperationException("WaterVision is not installed");
+   }
+}


### PR DESCRIPTION
Don't know if this is the best way to do this, but this did work for me.


Same thing works on Fabric, just fix the import path.