### PR TITLE
fix: remove unused import that causes NoClassDefFoundError

### DIFF
--- a/src/main/java/me/srrapero720/waterframes/common/compat/watervision/WVCompat.java
+++ b/src/main/java/me/srrapero720/waterframes/common/compat/watervision/WVCompat.java
@@ -1,7 +1,6 @@
 package me.srrapero720.waterframes.common.compat.watervision;
 
 import me.srrapero720.waterframes.WaterFrames;
-import me.srrapero720.watervision.client.screens.VisionScreen;
 import net.minecraft.client.Minecraft;
 
 import java.net.URI;


### PR DESCRIPTION
This appends to #222 because that fix is incomplete, the direct reference towards WaterVision mod classes were removed but the import is not removed, and the unused import remained in compiled bytecode so the client will still crash, making the fix totally invalid.
Tested in production environment and it worked well.

amend of https://github.com/SrRapero720/waterframes/commit/96c798c2e6ea3a7bb2609f538f66cdc66bf4ba6d
should fully closes #222
also relates to https://github.com/CreativeMD/CreativeCore/issues/290