### PR TITLE
Add Create Aeronautics Support to WaterFrames 1.21

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,6 +86,7 @@ jar {
         attributes "MixinConfigs"               : "$modid.$mixin_file_suffix"
     }
     exclude('org/valkyrienskies/**')
+    exclude('dev/ryanhcode/sable/companion/**')
 }
 
 publishMods {

--- a/src/main/java/dev/ryanhcode/sable/companion/SableCompanion.java
+++ b/src/main/java/dev/ryanhcode/sable/companion/SableCompanion.java
@@ -1,0 +1,10 @@
+package dev.ryanhcode.sable.companion;
+
+import net.minecraft.core.Position;
+import net.minecraft.world.level.Level;
+
+public interface SableCompanion {
+    SableCompanion INSTANCE = null;
+
+    double distanceSquaredWithSubLevels(Level level, Position pos1, Position pos2);
+}

--- a/src/main/java/me/srrapero720/waterframes/DisplaysConfig.java
+++ b/src/main/java/me/srrapero720/waterframes/DisplaysConfig.java
@@ -72,6 +72,7 @@ public class DisplaysConfig {
     private static final IntValue maxVolume;
     private static final BooleanValue useMasterVolume;
     private static final BooleanValue useVSEurekaCompat;
+    private static final BooleanValue useSableCompat;
     private static final BooleanValue useMultimedia;
     private static final BooleanValue keepRendering;
     // BEHAVIOR
@@ -156,6 +157,14 @@ public class DisplaysConfig {
                         "(This option is called VSEureka because valkirienskies is too long, and VS may be misleading)"
                 )
                 .define("vsEurekaCompat", true);
+
+        useSableCompat = SERVER
+                .comment(
+                        "Enables compatibility with Sable (used by Create: Simulated / Aeronautics contraptions)",
+                        "Projects sub-level block positions to global space so audio attenuates correctly from contraption-mounted displays",
+                        "Disable if sable misbehaves or audio stops working while using it"
+                )
+                .define("sableCompat", true);
 
         // WATERFRAMES -> multimedia -> watermedia
         SERVER.push("watermedia");
@@ -340,6 +349,7 @@ public class DisplaysConfig {
     public static int maxVolDis(int value) { return Math.min(value, maxVolDis()); }
     public static boolean useMasterVolume() { return useMasterVolume.get(); }
     public static boolean vsEurekaCompat() { return useVSEurekaCompat.get(); }
+    public static boolean sableCompat() { return useSableCompat.get(); }
 
     public static int maxVol() { return maxVolume.get(); }
     public static int maxVol(int value) { return Math.max(Math.min(value, maxVol()), 0); }

--- a/src/main/java/me/srrapero720/waterframes/WaterFrames.java
+++ b/src/main/java/me/srrapero720/waterframes/WaterFrames.java
@@ -2,6 +2,7 @@ package me.srrapero720.waterframes;
 
 import me.srrapero720.waterframes.client.display.DisplayList;
 import me.srrapero720.waterframes.common.block.entity.DisplayTile;
+import me.srrapero720.waterframes.common.compat.sable.SableCompat;
 import me.srrapero720.waterframes.common.compat.valkyrienskies.VSCompat;
 import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
@@ -104,6 +105,9 @@ public class WaterFrames {
     }
 
     public static double getDistance(Level level, BlockPos pos, Position position) {
+        if (SableCompat.installed() && DisplaysConfig.sableCompat()) {
+            return Math.sqrt(SableCompat.getSquaredDistance(level, pos, position));
+        }
         if (VSCompat.installed() && DisplaysConfig.vsEurekaCompat()) {
             return Math.sqrt(VSCompat.getSquaredDistance(level, pos, position));
         }

--- a/src/main/java/me/srrapero720/waterframes/common/compat/sable/SableCompat.java
+++ b/src/main/java/me/srrapero720/waterframes/common/compat/sable/SableCompat.java
@@ -1,0 +1,24 @@
+package me.srrapero720.waterframes.common.compat.sable;
+
+import dev.ryanhcode.sable.companion.SableCompanion;
+import me.srrapero720.waterframes.WaterFrames;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Position;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+
+public class SableCompat {
+    public static final boolean SABLE_MODE = WaterFrames.isInstalled("sable");
+
+    public static boolean installed() {
+        return SABLE_MODE;
+    }
+
+    public static double getSquaredDistance(Level level, BlockPos pos, Position pos2) {
+        return getSquaredDistance(level, Vec3.atCenterOf(pos), pos2);
+    }
+
+    public static double getSquaredDistance(Level level, Vec3 pos, Position pos2) {
+        return SableCompanion.INSTANCE.distanceSquaredWithSubLevels(level, pos, pos2);
+    }
+}


### PR DESCRIPTION
Small change trying to match the implementation of valkyrien skies support to fix audio broadcasting from physics entity -> world space.

Uses Sable Companion functions to calculate distance from a waterframes audio source to world. Sable Companion is stubbed out in a similar manner to VSGameUtilsKt.

Ideally, this can be a side patch before WaterFrames 3 enters development, and hopefully alleviate a lot of the WHER AERONAUTIC!!!11! comments.

